### PR TITLE
1 create matchers for exception cause

### DIFF
--- a/src/main/java/com/_4point/testing/matchers/javalang/ExceptionMatchers.java
+++ b/src/main/java/com/_4point/testing/matchers/javalang/ExceptionMatchers.java
@@ -33,6 +33,10 @@ public class ExceptionMatchers {
 	 * @return the matcher
 	 */
 	public static Matcher<Throwable> exceptionMsgContainsAll(String firstExpectedString, String...expectedStrings) {
+		if (expectedStrings.length == 0) {
+			// Just one matcher, so use it directly (should produce a better error message)
+			return new ExceptionMsgContains(Matchers.containsString(firstExpectedString));
+		}
 		@SuppressWarnings("unchecked")
 		Matcher<String>[] containsList = Stream.concat( Stream.of(firstExpectedString), Arrays.stream(expectedStrings))
 											   .map(s->Matchers.containsString(s))
@@ -83,7 +87,7 @@ public class ExceptionMatchers {
 	@SafeVarargs
 	public static Matcher<Throwable> hasCauseMatching(Matcher<Throwable> matcher, Matcher<Throwable>...matchers) {
 		if (matchers.length == 0) {
-			// Just one matcher
+			// Just one matcher, so use it directly (should produce a better error message)
 			return new HasCauseMatching(matcher);
 		}
 		@SuppressWarnings("unchecked")

--- a/src/main/java/com/_4point/testing/matchers/javalang/ExceptionMatchers.java
+++ b/src/main/java/com/_4point/testing/matchers/javalang/ExceptionMatchers.java
@@ -1,6 +1,6 @@
 package com._4point.testing.matchers.javalang;
 
-import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.Arrays;
@@ -13,6 +13,7 @@ import org.hamcrest.Matchers;
 /**
  * Matchers used for testing `java.lang.Exception`s (and its subclasses).
  *
+ *	Based on https://www.planetgeek.ch/2012/03/07/create-your-own-matcher/
  */
 public class ExceptionMatchers {
 
@@ -31,7 +32,7 @@ public class ExceptionMatchers {
 	 * 	additional strings that are expected to be in the message
 	 * @return the matcher
 	 */
-	public static Matcher<Exception> exceptionMsgContainsAll(String firstExpectedString, String...expectedStrings) {
+	public static Matcher<Throwable> exceptionMsgContainsAll(String firstExpectedString, String...expectedStrings) {
 		@SuppressWarnings("unchecked")
 		Matcher<String>[] containsList = Stream.concat( Stream.of(firstExpectedString), Arrays.stream(expectedStrings))
 											   .map(s->Matchers.containsString(s))
@@ -39,18 +40,69 @@ public class ExceptionMatchers {
 		return new ExceptionMsgContains(allOf(containsList));
 	}
 
-	private static class ExceptionMsgContains extends FeatureMatcher<Exception, String> {
+	private static class ExceptionMsgContains extends FeatureMatcher<Throwable, String> {
 
 		public ExceptionMsgContains(Matcher<String> subMatcher) {
 			super(subMatcher, "Exception message", "Exception message");
 		}
 
 		@Override
-		protected String featureValueOf(Exception actual) {
+		protected String featureValueOf(Throwable actual) {
 			String msg = actual.getMessage();
 			assertNotNull(msg, "Exception message was null.");
 			return msg;
 		}
 
 	}
+	
+	/**
+	 * Matcher that validates the cause of an exception is the cause exception provided.
+	 * 
+	 * The provided cause exception must be the same instance as cause in the exception being tested.
+	 * 
+	 * @param throwable
+	 * 	the expected cause exception
+	 * @return the matcher
+	 */
+	public static Matcher<Throwable> hasCause(Throwable throwable) {
+		return new HasCause(throwable);
+	}
+
+	private static class HasCause extends FeatureMatcher<Throwable, Throwable> {
+
+		public HasCause(Throwable throwable) {
+			super(sameInstance(throwable), "an exception with cause", "cause");
+		}
+
+		@Override
+		protected Throwable featureValueOf(Throwable actual) {
+			return actual.getCause();
+		}
+	}
+	
+	@SafeVarargs
+	public static Matcher<Throwable> hasCauseMatching(Matcher<Throwable> matcher, Matcher<Throwable>...matchers) {
+		if (matchers.length == 0) {
+			// Just one matcher
+			return new HasCauseMatching(matcher);
+		}
+		@SuppressWarnings("unchecked")
+		Matcher<Throwable>[] allMatchers = Stream.concat(Stream.of(matcher), Arrays.stream(matchers))
+												 .toArray(Matcher[]::new);
+		return new HasCauseMatching(allOf(allMatchers));
+	}	
+
+	private static class HasCauseMatching extends FeatureMatcher<Throwable, Throwable> {
+
+		public HasCauseMatching(Matcher<Throwable> subMatcher) {
+			super(subMatcher,"an exception with cause", "cause");
+		}
+
+		@Override
+		protected Throwable featureValueOf(Throwable actual) {
+			return actual.getCause();
+		}
+		
+	}
+
 }

--- a/src/test/java/com/_4point/testing/matchers/javalang/ExceptionMatchersTest.java
+++ b/src/test/java/com/_4point/testing/matchers/javalang/ExceptionMatchersTest.java
@@ -12,73 +12,45 @@ import org.junit.jupiter.params.provider.EnumSource;
 
 class ExceptionMatchersTest {
 
-	@Test
-	void testExceptionMsgContainsAll_OneString_Match() {
-		String expectedMsg = "Test Exception Message";
-		var testException = new IllegalStateException(expectedMsg);
-		
-		assertThat(testException, exceptionMsgContainsAll(expectedMsg));
+	private static final String EXPECTED_PARTIAL_MSG_1 = "Test";
+	private static final String EXPECTED_PARTIAL_MSG_2 = "Exception";
+	private static final String EXPECTED_PARTIAL_MSG_3 = "Message";
+	private static final String EXPECTED_MSG = EXPECTED_PARTIAL_MSG_1 + " " + EXPECTED_PARTIAL_MSG_2 + " " + EXPECTED_PARTIAL_MSG_3;
+	private static final String MISMATCH_STRING = " foo";
+	
+	private enum ExceptionMsgContainsAllScenario {
+		ONE_STRING(exceptionMsgContainsAll(EXPECTED_MSG), exceptionMsgContainsAll(EXPECTED_MSG + MISMATCH_STRING)),
+		TWO_STRINGS(exceptionMsgContainsAll(EXPECTED_PARTIAL_MSG_1, EXPECTED_PARTIAL_MSG_2), exceptionMsgContainsAll(EXPECTED_PARTIAL_MSG_1, MISMATCH_STRING)),
+		THREE_STRINGS(exceptionMsgContainsAll(EXPECTED_PARTIAL_MSG_1, EXPECTED_PARTIAL_MSG_2, EXPECTED_PARTIAL_MSG_3), exceptionMsgContainsAll(MISMATCH_STRING, EXPECTED_PARTIAL_MSG_2, EXPECTED_PARTIAL_MSG_3)),
+		;
+	
+		private final Matcher<Throwable> passingTest;
+		private final Matcher<Throwable> failingTest;
+
+		private ExceptionMsgContainsAllScenario(Matcher<Throwable> matcher, Matcher<Throwable> matcher2) {
+			this.passingTest = matcher;
+			this.failingTest = matcher2;
+		}
 	}
 
-	@Test
-	void testExceptionMsgContainsAll_OneString_Mismatch() {
-		String expectedMsg = "Test Exception Message";
-		String mismatchString = " foo";
-		var testException = new IllegalStateException(expectedMsg);
+	@ParameterizedTest
+	@EnumSource
+	void testExceptionMsgContainsAll_Match(ExceptionMsgContainsAllScenario scenario) {
+		var testException = new IllegalStateException(EXPECTED_MSG);
 		
-		AssertionError ex = assertThrows(AssertionError.class, ()->assertThat(testException, exceptionMsgContainsAll(expectedMsg + mismatchString)));
+		assertThat(testException, scenario.passingTest);
+	}
+
+	@ParameterizedTest
+	@EnumSource
+	void testExceptionMsgContainsAll_Mismatch(ExceptionMsgContainsAllScenario scenario) {
+		var testException = new IllegalStateException(EXPECTED_MSG);
+		
+		AssertionError ex = assertThrows(AssertionError.class, ()->assertThat(testException, scenario.failingTest));
 
 		String msg = ex.getMessage();
 		assertNotNull(msg);
-		assertThat(msg, allOf(containsString(expectedMsg), containsString(mismatchString)));
-	}
-
-	@Test
-	void testExceptionMsgContainsAll_TwoStrings_Match() {
-		String expectedMsg1 = "Test Exception";
-		String expectedMsg2 = "Message";
-		var testException = new IllegalStateException(expectedMsg1 + " " + expectedMsg2);
-		
-		assertThat(testException, exceptionMsgContainsAll(expectedMsg1, expectedMsg2));
-	}
-
-	@Test
-	void testExceptionMsgContainsAll_TwoStrings_Mismatch() {
-		String expectedMsg1 = "Test Exception";
-		String expectedMsg2 = "Message";
-		String mismatchString = " foo";
-		var testException = new IllegalStateException(expectedMsg1 + " " + expectedMsg2);
-		
-		AssertionError ex = assertThrows(AssertionError.class, ()->assertThat(testException, exceptionMsgContainsAll(expectedMsg1, expectedMsg2, mismatchString)));
-
-		String msg = ex.getMessage();
-		assertNotNull(msg);
-		assertThat(msg, allOf(containsString(expectedMsg1), containsString(expectedMsg2), containsString(mismatchString)));
-	}
-
-	@Test
-	void testExceptionMsgContainsAll_ThreeStrings_Match() {
-		String expectedMsg1 = "Test";
-		String expectedMsg2 = "Exception";
-		String expectedMsg3 = "Message";
-		var testException = new IllegalStateException(expectedMsg1 + " " + expectedMsg2 + " - " + expectedMsg3);
-		
-		assertThat(testException, exceptionMsgContainsAll(expectedMsg1, expectedMsg2, expectedMsg3));
-	}
-
-	@Test
-	void testExceptionMsgContainsAll_ThreeStrings_Mismatch() {
-		String expectedMsg1 = "Test";
-		String expectedMsg2 = "Exception";
-		String expectedMsg3 = "Message";
-		String mismatchString = " foo";
-		var testException = new IllegalStateException(expectedMsg1 + " " + expectedMsg2 + " - " + expectedMsg3);
-		
-		AssertionError ex = assertThrows(AssertionError.class, ()->assertThat(testException, exceptionMsgContainsAll(expectedMsg1, expectedMsg2, expectedMsg3, mismatchString)));
-
-		String msg = ex.getMessage();
-		assertNotNull(msg);
-		assertThat(msg, allOf(containsString(expectedMsg1), containsString(expectedMsg2), containsString(expectedMsg3), containsString(mismatchString)));
+		assertThat(msg, allOf(containsString(EXPECTED_PARTIAL_MSG_1), containsString(EXPECTED_PARTIAL_MSG_2), containsString(EXPECTED_PARTIAL_MSG_3), containsString(MISMATCH_STRING)));
 	}
 
 	@Test

--- a/src/test/java/com/_4point/testing/matchers/javalang/ExceptionMatchersTest.java
+++ b/src/test/java/com/_4point/testing/matchers/javalang/ExceptionMatchersTest.java
@@ -1,11 +1,14 @@
 package com._4point.testing.matchers.javalang;
 
-import static com._4point.testing.matchers.javalang.ExceptionMatchers.exceptionMsgContainsAll;
+import static com._4point.testing.matchers.javalang.ExceptionMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat; 
 import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.*;
 
+import org.hamcrest.Matcher;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 class ExceptionMatchersTest {
 
@@ -88,5 +91,64 @@ class ExceptionMatchersTest {
 		assertThat(msg, containsString("Exception message was null."));
 	}
 
+	private static final String CAUSE_EXCEPTION_MSG = "Cause Exception";
+	private static final Exception CAUSE_EXCEPTION = new IllegalStateException(CAUSE_EXCEPTION_MSG);
+	private static final Exception TEST_EXCEPTION = new IllegalStateException("Test Exception", CAUSE_EXCEPTION);
+	private static final Exception NON_CAUSE_EXCEPTION = new IllegalStateException("Non-cause Exception");
+
+	@Test
+	void testHasCause_Match() {
+		assertThat(TEST_EXCEPTION,hasCause(CAUSE_EXCEPTION));
+	}
+
+	@Test
+	void testHasCause_Mismatch() {
+		AssertionError ex = assertThrows(AssertionError.class, ()->assertThat(TEST_EXCEPTION,hasCause(NON_CAUSE_EXCEPTION)));
+		
+		String msg = ex.getMessage();
+		assertNotNull(msg);
+		assertThat(msg, containsString("an exception with cause"));		
+	}
+	
+	
+	private enum ExceptionCauseMatchesScenario {
+		ONE_EXCEPTION(
+				hasCauseMatching(sameInstance(CAUSE_EXCEPTION)), 
+				hasCauseMatching(sameInstance(NON_CAUSE_EXCEPTION))
+				),
+		TWO_EXCEPTIONS(
+				hasCauseMatching(exceptionMsgContainsAll(CAUSE_EXCEPTION_MSG), sameInstance(CAUSE_EXCEPTION)),
+				hasCauseMatching(exceptionMsgContainsAll(CAUSE_EXCEPTION_MSG), sameInstance(NON_CAUSE_EXCEPTION))
+				),
+		THREE_EXCEPTIONS(
+				hasCauseMatching(sameInstance(CAUSE_EXCEPTION), exceptionMsgContainsAll(CAUSE_EXCEPTION_MSG), sameInstance(CAUSE_EXCEPTION)),
+				hasCauseMatching(sameInstance(NON_CAUSE_EXCEPTION), exceptionMsgContainsAll(CAUSE_EXCEPTION_MSG), sameInstance(NON_CAUSE_EXCEPTION))
+			),
+		;
+		
+		private final Matcher<Throwable> passingTest;
+		private final Matcher<Throwable> failingTest;
+
+		private ExceptionCauseMatchesScenario(Matcher<Throwable> passingTest, Matcher<Throwable> failingTest) {
+			this.passingTest = passingTest;
+			this.failingTest = failingTest;
+		}
+	}
+	
+	@ParameterizedTest
+	@EnumSource
+	void testHasCauseMatching_Match(ExceptionCauseMatchesScenario scenario) {
+		assertThat(TEST_EXCEPTION, scenario.passingTest);
+	}
+
+	@ParameterizedTest
+	@EnumSource
+	void testHasCauseMatching_Mismatch(ExceptionCauseMatchesScenario scenario) {
+		AssertionError ex = assertThrows(AssertionError.class, ()->assertThat(TEST_EXCEPTION, scenario.failingTest));
+		
+		String msg = ex.getMessage();
+		assertNotNull(msg);
+		assertThat(msg, containsString("an exception with cause"));		
+	}
 
 }

--- a/src/test/java/com/_4point/testing/matchers/javalang/ExceptionMatchersTest.java
+++ b/src/test/java/com/_4point/testing/matchers/javalang/ExceptionMatchersTest.java
@@ -110,6 +110,15 @@ class ExceptionMatchersTest {
 		assertThat(msg, containsString("an exception with cause"));		
 	}
 	
+	@Test
+	void testHasCause_NoCause() {
+		AssertionError ex = assertThrows(AssertionError.class, ()->assertThat(CAUSE_EXCEPTION,hasCause(CAUSE_EXCEPTION)));
+		
+		String msg = ex.getMessage();
+		assertNotNull(msg);
+		assertThat(msg, containsString("an exception with cause"));		
+	}
+
 	
 	private enum ExceptionCauseMatchesScenario {
 		ONE_EXCEPTION(
@@ -145,6 +154,15 @@ class ExceptionMatchersTest {
 	@EnumSource
 	void testHasCauseMatching_Mismatch(ExceptionCauseMatchesScenario scenario) {
 		AssertionError ex = assertThrows(AssertionError.class, ()->assertThat(TEST_EXCEPTION, scenario.failingTest));
+		
+		String msg = ex.getMessage();
+		assertNotNull(msg);
+		assertThat(msg, containsString("an exception with cause"));		
+	}
+
+	@Test
+	void testHasCauseMatching_NoCause() {
+		AssertionError ex = assertThrows(AssertionError.class, ()->assertThat(CAUSE_EXCEPTION, hasCauseMatching(sameInstance(CAUSE_EXCEPTION))));
 		
 		String msg = ex.getMessage();
 		assertNotNull(msg);


### PR DESCRIPTION
Created matchers for Exception's cause.

Also refactored the exception message tests to make them more concise (and DRYer).

Added check to avoid allOf() when comparing only one only checking one string.